### PR TITLE
Enable client side bag naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,28 +13,34 @@ Rosbag files are saved with the current date and time as a filename.
 
 ## Usage
 
-The package creates three services, which can be called with a `std_srvs.srv.TriggerRequest` message:
-* /data\_recording/start\_recording
-* /data\_recording/stop\_recording
-* /data\_recording/toggle\_recording
+The package creates three services:
+* `/data\_recording/start\_recording` which can be called with a `std_srvs.srv.RecordRequest` message
+* `/data\_recording/stop\_recording` which can be called with a `std_srvs.srv.TriggerRequest` message
+* `/data\_recording/toggle\_recording` which can be called with a `std_srvs.srv.TriggerRequest` message
 
-Add the following import to your ROS node:
+Add the following imports to your ROS node:
 
-`from std_srvs.srv import Trigger`
+```python
+from std_srvs.srv import Trigger, TriggerRequest
+from data_recording.srv import Record, RecordRequest
+```
 
 In the init of your ROS node, launch the services as
 ```python
-start_record_srv = rospy.ServiceProxy('/data_recording/start_recording', Trigger)
+start_record_srv = rospy.ServiceProxy('/data_recording/start_recording', Record)
 stop_record_srv = rospy.ServiceProxy('/data_recording/stop_recording', Trigger)
 ```
 
 Then in a regular service call:
 
 ```python
-start_record_srv(TriggerRequest())
+start_record_srv(RecordRequest('name of your file')  # this allows you to modify name based on e.g. the run
 do_some_stuff()
 stop_record_srv(TriggerRequest())
 ```
+
+If you leave the `bagname` field of the `RecordRequest` empty, the file will be named using 
+the datetime of the recording.
 
 ### Annotations
 

--- a/data_recording/CMakeLists.txt
+++ b/data_recording/CMakeLists.txt
@@ -7,7 +7,10 @@ project(data_recording)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+             rospy
+             std_msgs
+             message_generation)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -50,11 +53,10 @@ find_package(catkin REQUIRED)
 # )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  Record.srv
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -64,10 +66,10 @@ find_package(catkin REQUIRED)
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
+generate_messages(
+  DEPENDENCIES
+  std_msgs  # Or other packages containing msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -101,7 +103,7 @@ find_package(catkin REQUIRED)
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES data_recording
-#  CATKIN_DEPENDS other_catkin_pkg
+  CATKIN_DEPENDS message_runtime
 #  DEPENDS system_lib
 )
 

--- a/data_recording/launch/data_recording.launch
+++ b/data_recording/launch/data_recording.launch
@@ -13,6 +13,6 @@
       <rosparam param="output_directory" subst_value="true">$(arg output_dir)</rosparam>
     </group>
 
-    <node name="data_recording" pkg="data_recording" type="data_recording.py" output="screen" />
+    <node name="recorder" pkg="data_recording" type="recorder.py" output="screen" />
 
 </launch>

--- a/data_recording/package.xml
+++ b/data_recording/package.xml
@@ -40,7 +40,8 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-
+  <build_depend>message_generation</build_depend>
+  <run_depend>message_runtime</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/data_recording/scripts/example.py
+++ b/data_recording/scripts/example.py
@@ -4,11 +4,12 @@
 import rospy
 
 from std_srvs.srv import Trigger, TriggerRequest
+from data_recording.srv import Record, RecordRequest
 from visualization_msgs.msg import Marker
 
 
 def something_interesting():
-    """Dummy thing that takes up time"""
+    """Dummy thing that takes up time and publishes annotations"""
     global annotation_pub
 
     rospy.sleep(4)
@@ -62,14 +63,17 @@ def create_text_marker(text, position, orientation=[0, 0, 0, 1], frame_id='/worl
 
 if __name__ == '__main__':
     rospy.init_node('recording_example')
-    rospy.loginfo('starting recording example')
+    rospy.loginfo('starting recording example, waiting for services to come up...')
 
-    start_record_srv = rospy.ServiceProxy('/data_recording/start_recording', Trigger)
+    rospy.wait_for_service('/data_recording/start_recording')
+    rospy.wait_for_service('/data_recording/stop_recording')
+    rospy.loginfo('...services up')
+    start_record_srv = rospy.ServiceProxy('/data_recording/start_recording', Record)
     stop_record_srv = rospy.ServiceProxy('/data_recording/stop_recording', Trigger)
 
     annotation_pub = rospy.Publisher('/data_recording/annotations', Marker, queue_size=10)
 
-    start_record_srv(TriggerRequest())
+    start_record_srv(RecordRequest('example_annotations'))
     # now do something we want to record
     try:
         something_interesting()

--- a/data_recording/srv/Record.srv
+++ b/data_recording/srv/Record.srv
@@ -1,0 +1,5 @@
+# Similar to the std_srvs/Trigger service, but include an input to take a rosbag filename
+string bagname
+---
+bool success
+string message


### PR DESCRIPTION
Instead of default naming the bag with the datetime, allow the user to override that setting through the service request. This allows naming sensible names with the number of the run of an experiment, a setting, a time, and more.
Had to change naming of `data_recording.py` to something else as naming the python file the same as Python didn't like that when importing the package itself.

See the README